### PR TITLE
Feature add rgbled getian gt p6 prgb4303

### DIFF
--- a/LED_RGB_Getian_GT-P6PRGB4303.kicad_mod
+++ b/LED_RGB_Getian_GT-P6PRGB4303.kicad_mod
@@ -1,7 +1,7 @@
 (module LED_RGB_Getian_GT-P6PRGB4303 (layer F.Cu)
   (descr https://www.gme.sk/img/cache/doc/518/177/vykonova-led-getian-gt-p6prgb4303-datasheet-1.pdf)
   (tags "LED RGB ")
-  (fp_text reference D? (at 0 -5.4) (layer Cmts.User)
+  (fp_text reference D? (at 0 -5.4) (layer F.SilkS)
     (effects (font (size 1.5 1.5) (thickness 0.15)))
   )
   (fp_text value LED_RGB_Getian_GT-P6PRGB4303 (at 0 5.45) (layer F.SilkS) hide


### PR DESCRIPTION
Adds 6-pin RGB LED  gt-p6-prgb4303.
Datasheet is available at https://www.gme.sk/img/cache/doc/518/177/vykonova-led-getian-gt-p6prgb4303-datasheet-1.pdf.
Silkscreen uses 0.15mm width, 0.15 mm clearence from pads and is visible after assembly. 
Silkscreen has a reference mark for pin 1, red anode.  Pin 1 is at top left.
Origin is at middle of part.
Pins are named by function "Red anode"->RA, "green cathode"->GC etc. to avoid ambiguity. 

Related library symbol: https://github.com/ojousima/kicad-library/commit/4468819620dfeaf375495d03069b5214a78cd73e.
