### PR TITLE
Fixed 3D model orientation for 'LED_0402.kicad_mod'.

### DIFF
--- a/LED_0402.kicad_mod
+++ b/LED_0402.kicad_mod
@@ -21,6 +21,6 @@
   (model LEDs.3dshapes/LED_0402.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
-    (rotate (xyz 0 0 0))
+    (rotate (xyz 0 0 180))
   )
 )


### PR DESCRIPTION
Off by 180° (A/K reversed)