### PR TITLE
Rename LED-XP-G_CREE to LED_CREE-XP-G

### DIFF
--- a/LED_CREE-XP-G.kicad_mod
+++ b/LED_CREE-XP-G.kicad_mod
@@ -20,10 +20,13 @@
   (fp_line (start -1.8 -1.8) (end 1.8 -1.8) (layer F.SilkS) (width 0.12))
   (fp_line (start 1.8 1.8) (end -1.8 1.8) (layer F.SilkS) (width 0.12))
   (fp_line (start -1.8 1.8) (end -1.8 -1.8) (layer F.SilkS) (width 0.12))
+  (fp_text user %R (at 0 0) (layer F.Fab)
+    (effects (font (size 0.8 0.8) (thickness 0.08)))
+  )
   (pad 2 smd rect (at 1.4 0) (size 0.5 3.3) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -1.4 0) (size 0.5 3.3) (layers F.Cu F.Paste F.Mask))
   (pad 3 smd rect (at 0 0) (size 1.3 3.3) (layers F.Cu F.Paste F.Mask))
-  (model LEDs.3dshapes/LED_CREE-XP-G.wrl
+  (model ${KISYS3DMOD}/LEDs.3dshapes/LED_CREE-XP-G.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/LED_CREE-XP-G.kicad_mod
+++ b/LED_CREE-XP-G.kicad_mod
@@ -1,11 +1,11 @@
-(module LED-XP-G_CREE (layer F.Cu) (tedit 587A7054)
+(module LED_CREE-XP-G (layer F.Cu) (tedit 587A7054)
   (descr http://www.cree.com/~/media/Files/Cree/LED%20Components%20and%20Modules/XLamp/Data%20and%20Binning/XLampXPG.pdf)
-  (tags "LED XP-G CREE")
+  (tags "LED CREE XP-G")
   (attr smd)
   (fp_text reference REF** (at 0 2.9) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value LED-XP-G_CREE (at 0 -2.9) (layer F.Fab)
+  (fp_text value LED_CREE-XP-G (at 0 -2.9) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_circle (center 0 0) (end 0 1.3) (layer F.Fab) (width 0.1))
@@ -23,7 +23,7 @@
   (pad 2 smd rect (at 1.4 0) (size 0.5 3.3) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -1.4 0) (size 0.5 3.3) (layers F.Cu F.Paste F.Mask))
   (pad 3 smd rect (at 0 0) (size 1.3 3.3) (layers F.Cu F.Paste F.Mask))
-  (model LEDs.3dshapes/LED-XP-G_CREE.wrl
+  (model LEDs.3dshapes/LED_CREE-XP-G.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Use naming paradigm for all the rest of the LEDs. No changes other than footprint name.